### PR TITLE
feat(Configurations.receipts): Make total net printing configurable

### DIFF
--- a/lib/v1/configurations/items/receipts.js
+++ b/lib/v1/configurations/items/receipts.js
@@ -103,6 +103,19 @@ module.exports = {
                   ]
                 }
               })
+            },
+            print_total_net: {
+              ...oneOf({
+                description: 'Defines the receipt-types the total net will be printed on (e.g. customer, merchant)',
+                type: 'array',
+                items: {
+                  type: 'string',
+                  'enum': [
+                    'merchant',
+                    'customer'
+                  ]
+                }
+              })
             }
           }
         })


### PR DESCRIPTION
Total net should only be printed on configured receipt types

TM-4346