### PR TITLE
fix(devices): enforce device id max length

### DIFF
--- a/lib/v0/devices/base.js
+++ b/lib/v0/devices/base.js
@@ -12,7 +12,9 @@ module.exports = {
     format: 'uuid'
   },
   device_id: {
-    type: 'string'
+    type: 'string',
+    minLength: 1,
+    maxLength: 36
   },
   register: {
     type: 'string',


### PR DESCRIPTION
36 is the length of a UUID string