### PR TITLE
feat(register-opening-protocols): change required fields

### DIFF
--- a/lib/v0/register_opening_protocols/create.js
+++ b/lib/v0/register_opening_protocols/create.js
@@ -8,8 +8,8 @@ module.exports.request = {
   type: 'object',
   required: [
     'cash_units',
-    'register',
-    'branch',
+    'register_custom_id',
+    'branch_custom_id',
     'opening_date'
   ],
   properties: base
@@ -25,8 +25,8 @@ module.exports.response = {
     'created_at',
     'updated_at',
     'cash_units',
-    'register',
-    'branch',
+    'register_custom_id',
+    'branch_custom_id',
     'opening_date'
   ],
   properties: defaultResponse

--- a/lib/v0/register_opening_protocols/get.js
+++ b/lib/v0/register_opening_protocols/get.js
@@ -3,22 +3,20 @@ const defaultResponse = require('./default-response')
 const latestRequest = {
   $id: 'https://schemas.tillhub.com/v0/register_opening_protocols.get.latest.request.schema.json',
   $schema: 'http://json-schema.org/draft-07/schema#',
-  additionalProperties: false,
+  additionalProperties: true,
   type: 'object',
   required: [
-    'register',
-    'branch'
+    'register_custom_id',
+    'branch_custom_id'
   ],
   properties: {
-    register: {
+    register_custom_id: {
       type: 'string',
-      description: 'The alphanumeric uuid of the register',
-      format: 'uuid'
+      description: 'The alphanumeric uuid of the register_custom_id'
     },
-    branch: {
+    branch_custom_id: {
       type: 'string',
-      description: 'The alphanumeric uuid of the register',
-      format: 'uuid'
+      description: 'The alphanumeric uuid of the branch_custom_id'
     }
   }
 }
@@ -33,8 +31,8 @@ const latestResponse = {
     'created_at',
     'updated_at',
     'cash_units',
-    'register',
-    'branch',
+    'register_custom_id',
+    'branch_custom_id',
     'opening_date'
   ],
   properties: defaultResponse


### PR DESCRIPTION
Make branch_custom_id and register_custom_id required, due to changes in query params of the "get
latest protocol" endpoint