### PR TITLE
feat(configurations): add require_sales for balances

### DIFF
--- a/lib/v1/configurations/items/balances.js
+++ b/lib/v1/configurations/items/balances.js
@@ -14,6 +14,18 @@ module.exports = {
         }
       ]
     },
+    sales_required: {
+      description: 'If true, balances are not conductable without fiat/cash cashflows.',
+      default: true,
+      oneOf: [
+        {
+          type: 'null'
+        },
+        {
+          type: 'boolean'
+        }
+      ]
+    },
     discrepancy_warning: {
       description: 'If true, warns the user when cash counted is not equal to cash calculated.',
       default: true,


### PR DESCRIPTION
Extending the balance feature configuration to control whether balance creation is actually possible without any cash cashflow over the course of the business day.