### PR TITLE
feat(cart_items): unify fields across TX, DN, SC

### DIFF
--- a/lib/v1/carts/items/create.js
+++ b/lib/v1/carts/items/create.js
@@ -1,3 +1,7 @@
+const { oneOf } = require('../../../helpers/payload-or-null')
+const productServiceAnswerObject = require('../../transactions/components/embedded/product_service_answer/base')
+const returnReason = require('../../transactions/components/embedded/return/return_reason')
+const voucherObject = require('../../transactions/components/embedded/voucher/base')
 
 const masterData = {
   salesman_staff: {
@@ -584,6 +588,68 @@ const internalCart = {
     },
     amount: {
       ...amount
+    },
+    promotion_amount: oneOf({
+      description: 'The promotion amount on the per unit qty base of 1.',
+      type: 'number',
+      minimum: -1000000,
+      maximum: 1000000,
+      multipleOf: 0.01
+    }),
+    promotion_amount_total: oneOf({
+      description: 'The total promotion amount.',
+      type: 'number',
+      minimum: -1000000,
+      maximum: 1000000,
+      multipleOf: 0.01
+    }),
+    product_service_answers: oneOf({
+      type: 'array',
+      description: 'A list of answers to product service questions',
+      items: {
+        ...productServiceAnswerObject
+      }
+    }),
+    is_voucher: {
+      ...oneOf({
+        type: 'boolean',
+        default: false,
+        description: 'If true, this item represents a voucher and must come with voucher information in \'context\''
+      })
+    },
+    voucher: {
+      ...oneOf({
+        ...voucherObject
+      }),
+      default: null
+    },
+    is_refund: {
+      ...oneOf({
+        type: 'boolean',
+        description: 'If true, the item was created by (partially) refunding a previous sale.'
+      })
+    },
+    return_reason: returnReason,
+    attributes_description: {
+      ...oneOf({
+        type: 'string',
+        example: 'red | big | 32',
+        description: 'A short description of the child attributes in variant products'
+      })
+    },
+    reference_cartitem_client_id: {
+      ...oneOf({
+        type: 'string',
+        example: '01331B44-130B-45D4-97A7-401247FD5B68',
+        description: 'In cases of refund or cancellation, or invoicing a delivery note or selling a saved cart: the client_id of the origin item'
+      })
+    },
+    used_barcode: {
+      ...oneOf({
+        type: 'string',
+        example: '0E9761310XF',
+        description: 'The barcode used to trigger putting this item into the cart (defaults to the first available barcode from the product)'
+      })
     },
     ...base,
     discounts: internalDiscounts,

--- a/lib/v1/carts/items/create.js
+++ b/lib/v1/carts/items/create.js
@@ -614,7 +614,7 @@ const internalCart = {
       ...oneOf({
         type: 'boolean',
         default: false,
-        description: 'If true, this item represents a voucher and must come with voucher information in \'context\''
+        description: 'If true, this item represents a voucher and must come with voucher information in \'voucher\''
       })
     },
     voucher: {

--- a/lib/v1/delivery_notes/items/create.js
+++ b/lib/v1/delivery_notes/items/create.js
@@ -287,7 +287,7 @@ const internalCart = {
       ...oneOf({
         type: 'boolean',
         default: false,
-        description: 'If true, this item represents a voucher and must come with voucher information in \'context\''
+        description: 'If true, this item represents a voucher and must come with voucher information in \'voucher\''
       })
     },
     voucher: {

--- a/lib/v1/delivery_notes/items/create.js
+++ b/lib/v1/delivery_notes/items/create.js
@@ -1,3 +1,7 @@
+const { oneOf } = require('../../../helpers/payload-or-null')
+const productServiceAnswerObject = require('../../transactions/components/embedded/product_service_answer/base')
+const returnReason = require('../../transactions/components/embedded/return/return_reason')
+const voucherObject = require('../../transactions/components/embedded/voucher/base')
 
 const masterData = {
   salesman_staff: {
@@ -257,6 +261,68 @@ const internalCart = {
     },
     discount_amount_total: {
       type: 'number'
+    },
+    promotion_amount: oneOf({
+      description: 'The promotion amount on the per unit qty base of 1.',
+      type: 'number',
+      minimum: -1000000,
+      maximum: 1000000,
+      multipleOf: 0.01
+    }),
+    promotion_amount_total: oneOf({
+      description: 'The total promotion amount.',
+      type: 'number',
+      minimum: -1000000,
+      maximum: 1000000,
+      multipleOf: 0.01
+    }),
+    product_service_answers: oneOf({
+      type: 'array',
+      description: 'A list of answers to product service questions',
+      items: {
+        ...productServiceAnswerObject
+      }
+    }),
+    is_voucher: {
+      ...oneOf({
+        type: 'boolean',
+        default: false,
+        description: 'If true, this item represents a voucher and must come with voucher information in \'context\''
+      })
+    },
+    voucher: {
+      ...oneOf({
+        ...voucherObject
+      }),
+      default: null
+    },
+    is_refund: {
+      ...oneOf({
+        type: 'boolean',
+        description: 'If true, the item was created by (partially) refunding a previous sale.'
+      })
+    },
+    return_reason: returnReason,
+    attributes_description: {
+      ...oneOf({
+        type: 'string',
+        example: 'red | big | 32',
+        description: 'A short description of the child attributes in variant products'
+      })
+    },
+    reference_cartitem_client_id: {
+      ...oneOf({
+        type: 'string',
+        example: '01331B44-130B-45D4-97A7-401247FD5B68',
+        description: 'In cases of refund or cancellation, or invoicing a delivery note or selling a saved cart: the client_id of the origin item'
+      })
+    },
+    used_barcode: {
+      ...oneOf({
+        type: 'string',
+        example: '0E9761310XF',
+        description: 'The barcode used to trigger putting this item into the cart (defaults to the first available barcode from the product)'
+      })
     },
     ...base,
     attributes: {


### PR DESCRIPTION
add fields: promotion_amount, promotion_amount_total, product_service_answers, is_voucher, voucher, is_refund, return_reason, attributes_description, reference_cartitem_client_id and used_barcode fields

https://tillhub.atlassian.net/browse/TM-6813