### PR TITLE
feat(transactions): fiscal_signing

### DIFF
--- a/lib/v1/transactions/components/embedded/status/base.js
+++ b/lib/v1/transactions/components/embedded/status/base.js
@@ -118,7 +118,7 @@ module.exports = {
         client_id: {
           ...oneOf({
             type: 'string',
-            description: 'ID of the register according to the signing unit. Will deviate fron the Tillhub register UUID!',
+            description: 'ID of the register according to the signing unit. Will deviate from the Tillhub register UUID!',
             example: '955002-00'
           })
         },

--- a/lib/v1/transactions/components/embedded/status/base.js
+++ b/lib/v1/transactions/components/embedded/status/base.js
@@ -67,15 +67,26 @@ module.exports = {
         },
         data: {
           type: 'string',
-          example: 'NrKeZlh4xLMFS4MtJPoDP8GXPGpOw39\\/uSWYWCYa066Md7TXAL6Op0DWiB5y+dJdR1+P\\/vvtU2yPAJz9Cr2xcXsaPEoJQHTBJrEZ+Imbd7X9FMW+p3tJUeH+JAUPoDFh',
+          example: 'MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIM- WRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==',
           maxLength: 16384,
           description: 'The actual signature from the signing provider (data for backwards compatibility)'
         },
+        data_extended: {
+          ...oneOf({
+            type: 'string',
+            example: 'V0;955002-00;Kassenbeleg-V1;Beleg^0.00_2.55_0.00_0.00_0.00^2.55:Bar; 18;112;2019-07-10T18:41:04.000Z;2019-07-10T18:41:04.000Z;ecdsa-plain- SHA256;unixTime;MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIMWRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==;BHhWOeisRpPBTGQ1W4VUH95TXx2 GARf8e2NYZXJoInjtGqnxJ8sZ3CQpYgjI+LYEmW5A37sLWHsyU7nSJUBemyU=',
+            maxLength: 16384,
+            description: 'The extended signature that can be printed additionally (e.g. as QR-Code according to DSFinV- K vs. signature as string)'
+          })
+        },
         caption: {
-          default: null,
-          type: 'string',
-          minLength: 1,
-          maxLength: 128
+          ...oneOf({
+            default: null,
+            type: 'string',
+            description: 'Optional caption if the signature by itself will be printed as QR-Code',
+            minLength: 1,
+            maxLength: 128
+          })
         },
         payload: {
           description: 'The original signing response by the signing provider.',
@@ -84,7 +95,7 @@ module.exports = {
             {
               type: 'string',
               description: 'The stringified version of any raw response from any signing provider.',
-              example: '"{\\"function\\":\\"FinishTransaction\\",\\"output\\":{\\"logTime\\":\\"2020-06-30T12:34:53Z\\",\\"signature\\":\\"NrKeZlh4xLMFS4MtJPoDP8GXPGpOw39/uSWYWCYa066Md7TXAL6Op0DWiB5y+dJdR1+P/vvtU2yPAJz9Cr2xcXsaPEoJQHTBJrEZ+Imbd7X9FMW+p3tJUeH+JAUPoDFh\\",\\"signatureCounter\\":110},\\"result\\":\\"EXECUTION_OK\\"}"'
+              example: '{"function":"FinishTransaction","output":{"logTime":"2020-07-10T23:12:21Z","signature":"HRTC0sv6HhIcMY+l8MWk9DavvF8CAHwfOaONfN5sdCvyS8zSMHXOx4829DHtTLPyOKPDe+IgT4qbbiktuj0JF9Tc4QH\\/iZ0TQSEd4rCNrPMjfOQvJpLv8ybjAy7zWs4B","signatureCounter":227},"result":"EXECUTION_OK"}'
             },
             {
               type: 'object'
@@ -96,24 +107,84 @@ module.exports = {
           default: null,
           ...oneOf([
             {
-              type: 'string'
+              type: 'string',
+              example: '{"storage":{"type":"TSE","vendor":"TSE1"},"function":"FinishTransaction","input":{"clientId":"c5a3ce2d-61a9-4c63-8d63-17d83e","processType":"Finish","processData":"QmVsZWdeMjAuMDBfMC4wMF8wLjAwXzAuMDBfMC4wMF4yMC4wMDpVbmJhcg==","transactionNumber":16,"additionalData":""},"compress":{"type":"zip_deflate","required":true}}'
             },
             {
               type: 'object'
             }
           ])
         },
+        client_id: {
+          ...oneOf({
+            type: 'string',
+            description: 'ID of the register according to the signing unit. Will deviate fron the Tillhub register UUID!',
+            example: '955002-00'
+          })
+        },
         counter: {
           ...oneOf({
             type: 'integer',
             minimum: 0,
-            description: 'Internal counter of the signing unit'
+            description: 'Internal counter of the signing unit (signature counter)',
+            example: 227
           })
         },
         unit: {
           ...oneOf({
             type: 'string',
-            description: 'ID of the used signing unit'
+            description: 'ID of the used signing unit (e.g. Fiskaly: tss_id (UUID4), Epson: serialNumber (base64))',
+            example: 'soTFFH9xiZP9JYWCPRgvpw6xhZ3ttbWDjfS4ky4AMEk='
+          })
+        },
+        public_key: {
+          ...oneOf({
+            type: 'string',
+            description: 'Public key of the signing unit according to BSI TR-03111 (e.g. tsePublicKey for Epson)'
+          })
+        },
+        algorithm: {
+          ...oneOf({
+            type: 'string',
+            description: 'The algorith type used by the signing unit',
+            example: 'ecdsa-plain-SHA256'
+          })
+        },
+        processData: {
+          ...oneOf([
+            {
+              type: 'string',
+              example: 'Beleg^0.00_2.55_0.00_0.00_0.00^2.55:Bar',
+              maxLength: 1024,
+              description: 'The transaction relevant content as input for the signing algorithm'
+            }
+          ])
+        },
+        transaction_number: {
+          ...oneOf([
+            {
+              type: 'integer',
+              minimum: 0,
+              description: 'The transaction number according to the signing unit, required in final input data',
+              example: 16
+            }
+          ])
+        },
+        transaction_id: {
+          ...oneOf([
+            {
+              type: 'string',
+              description: 'The transaction id according to the signing unit (Fiskaly: _id)',
+              example: '00000000-0000-0000-0000-000000000000'
+            }
+          ])
+        },
+        started_at: {
+          ...oneOf({
+            type: 'string',
+            format: 'date-time',
+            example: '2019-07-10T18:41:02.000Z',
+            description: 'A signing system defined [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date e.g. 2018-01-29T14:55:05.000Z. This represents the time of any inital signing request (e.g. start_transaction according to DSFinV-K, Fiskaly: time_start)'
           })
         },
         error: {

--- a/lib/v1/transactions/components/embedded/status/base.js
+++ b/lib/v1/transactions/components/embedded/status/base.js
@@ -146,7 +146,7 @@ module.exports = {
         algorithm: {
           ...oneOf({
             type: 'string',
-            description: 'The algorith type used by the signing unit',
+            description: 'The algorithm type used by the signing unit',
             example: 'ecdsa-plain-SHA256'
           })
         },

--- a/lib/v1/transactions/components/embedded/status/base.js
+++ b/lib/v1/transactions/components/embedded/status/base.js
@@ -74,7 +74,7 @@ module.exports = {
         data_extended: {
           ...oneOf({
             type: 'string',
-            example: 'V0;955002-00;Kassenbeleg-V1;Beleg^0.00_2.55_0.00_0.00_0.00^2.55:Bar; 18;112;2019-07-10T18:41:04.000Z;2019-07-10T18:41:04.000Z;ecdsa-plain- SHA256;unixTime;MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIMWRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==;BHhWOeisRpPBTGQ1W4VUH95TXx2 GARf8e2NYZXJoInjtGqnxJ8sZ3CQpYgjI+LYEmW5A37sLWHsyU7nSJUBemyU=',
+            example: 'V0;955002-00;Kassenbeleg-V1;Beleg^0.00_2.55_0.00_0.00_0.00^2.55:Bar;18;112;2019-07-10T18:41:04.000Z;2019-07-10T18:41:04.000Z;ecdsa-plain- SHA256;unixTime;MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIMWRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==;BHhWOeisRpPBTGQ1W4VUH95TXx2 GARf8e2NYZXJoInjtGqnxJ8sZ3CQpYgjI+LYEmW5A37sLWHsyU7nSJUBemyU=',
             maxLength: 16384,
             description: 'The extended signature that can be printed additionally (e.g. as QR-Code according to DSFinV- K vs. signature as string)'
           })

--- a/lib/v1/transactions/components/embedded/status/base.js
+++ b/lib/v1/transactions/components/embedded/status/base.js
@@ -67,14 +67,14 @@ module.exports = {
         },
         data: {
           type: 'string',
-          example: 'MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIM- WRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==',
+          example: 'MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIMWRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==',
           maxLength: 16384,
           description: 'The actual signature from the signing provider (data for backwards compatibility)'
         },
-        data_extended: {
+        qr_code_data: {
           ...oneOf({
             type: 'string',
-            example: 'V0;955002-00;Kassenbeleg-V1;Beleg^0.00_2.55_0.00_0.00_0.00^2.55:Bar;18;112;2019-07-10T18:41:04.000Z;2019-07-10T18:41:04.000Z;ecdsa-plain- SHA256;unixTime;MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIMWRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==;BHhWOeisRpPBTGQ1W4VUH95TXx2 GARf8e2NYZXJoInjtGqnxJ8sZ3CQpYgjI+LYEmW5A37sLWHsyU7nSJUBemyU=',
+            example: 'V0;955002-00;Kassenbeleg-V1;Beleg^0.00_2.55_0.00_0.00_0.00^2.55:Bar;18;112;2019-07-10T18:41:04.000Z;2019-07-10T18:41:04.000Z;ecdsa-plain-SHA256;unixTime;MEQCIAy4P9k+7x9saDO0uRZ4El8QwN+qTgYiv1DIaJIMWRiuAiAt+saFDGjK2Yi5Cxgy7PprXQ5O0seRgx4ltdpW9REvwA==;BHhWOeisRpPBTGQ1W4VUH95TXx2GARf8e2NYZXJoInjtGqnxJ8sZ3CQpYgjI+LYEmW5A37sLWHsyU7nSJUBemyU=',
             maxLength: 16384,
             description: 'The extended signature that can be printed additionally (e.g. as QR-Code according to DSFinV- K vs. signature as string)'
           })
@@ -150,7 +150,7 @@ module.exports = {
             example: 'ecdsa-plain-SHA256'
           })
         },
-        processData: {
+        process_data: {
           ...oneOf([
             {
               type: 'string',

--- a/lib/v1/transactions/components/embedded/status/base.js
+++ b/lib/v1/transactions/components/embedded/status/base.js
@@ -150,6 +150,13 @@ module.exports = {
             example: 'ecdsa-plain-SHA256'
           })
         },
+        process_type: {
+          ...oneOf({
+            type: 'string',
+            description: 'A string describing the local type of the signing process',
+            example: 'Kassenbeleg-V1'
+          })
+        },
         process_data: {
           ...oneOf([
             {


### PR DESCRIPTION
extend signature for new signing processes

https://tillhub.atlassian.net/browse/TM-6961

it is still not clear if we could consider this a final contract... I would even be willing to split the different signature information (especially Austria vs. German DSFinV-K) into different layouts (admitted that this is driven from the type-safe mapping on the iOS client)

On a technical side: we will store raw JSON in some places... does this need to be escaped in the schema examples?