### PR TITLE
feat: explicit flag for printing used discounts

### DIFF
--- a/lib/v1/discounts/base.js
+++ b/lib/v1/discounts/base.js
@@ -206,12 +206,14 @@ module.exports = {
             ]
           },
           receipt: {
+            description: 'Describing the behaviour of the discount on the receipt.',
             oneOf: [
               {
                 type: 'object',
                 additionalProperties: false,
                 properties: {
                   print_explicitely: {
+                    description: 'Printing the grouped amount of this discount applied on the receipt, if the discount is found in one or more cartitems.',
                     type: 'boolean',
                     default: false
                   }

--- a/lib/v1/discounts/base.js
+++ b/lib/v1/discounts/base.js
@@ -204,6 +204,20 @@ module.exports = {
                 type: 'null'
               }
             ]
+          },
+          receipt: {
+            oneOf: [
+              {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  print_explicitely: {
+                    type: 'boolean',
+                    default: false
+                  }
+                }
+              }
+            ]
           }
         }
       },


### PR DESCRIPTION
As discussed, a proposal for the discount printing behavior on our receipts.
Following the request of Apollo, made it generic so that no string matching will be required in the feature, and we can satisfy multiple customers.