### PR TITLE
fix(transactions_v1): legacy_discounts

### DIFF
--- a/lib/v1/transactions/legacy/items/base.js
+++ b/lib/v1/transactions/legacy/items/base.js
@@ -298,7 +298,7 @@ module.exports = {
             minimum: 0,
             description: 'Position of that discount inside the list (application used to have unordered set previously)'
           },
-          type: {
+          type_name: {
             type: 'string',
             enum: [
               'percentage',


### PR DESCRIPTION
set key type_name as used by the client applications

https://tillhub.atlassian.net/browse/TM-7240

alongside we found this as not representing the actual table column's name
