### PR TITLE
fix(pricebook/entry): allow 4 decimals for discounts

### DIFF
--- a/lib/v1/products/prices/book/entry/base.js
+++ b/lib/v1/products/prices/book/entry/base.js
@@ -86,14 +86,14 @@ module.exports = {
     description: 'Relative value of this product based on any other applicable price.',
     ...oneOf({
       type: 'number',
-      multipleOf: 0.001
+      multipleOf: 0.0001
     })
   },
   discounted_by: {
     description: 'The discounting applied in the price book item',
     ...oneOf({
       type: 'number',
-      multipleOf: 0.001
+      multipleOf: 0.0001
     })
   },
   metadata: {


### PR DESCRIPTION
On the dashboard, we allow discount input as percent with two decimals.

E.g. 13,37% = 0.1337

Trying to save this returns 422 error, as it has to be a multiple of 0.001.