### PR TITLE
feat(registers): counting_decision

### DIFF
--- a/lib/common/counting_decision.js
+++ b/lib/common/counting_decision.js
@@ -1,45 +1,10 @@
-const countingNumbers = {
-  type: 'object',
-  additionalProperties: false,
-  properties: {
-    sale: {
-      type: 'integer',
-      description: 'The sale counting number at the time of the decision.',
-      example: 37,
-      minimum: 0
-    },
-    expense: {
-      type: 'integer',
-      description: 'The expense counting number at the time of the decision.',
-      example: 19,
-      minimum: 0
-    },
-    balance: {
-      type: 'integer',
-      description: 'The balance counting number at the time of the decision.',
-      example: 5,
-      minimum: 0
-    },
-    delivery_note: {
-      type: 'integer',
-      description: 'The delivery note counting number at the time of the decision.',
-      example: 3,
-      minimum: 0
-    },
-    saved_cart: {
-      type: 'integer',
-      description: 'The saved cart counting number at the time of the decision.',
-      example: 29,
-      minimum: 0
-    }
-  }
-}
+const { oneOf } = require('../helpers/payload-or-null')
 
 module.exports = {
   type: 'object',
   additionalProperties: false,
-  description: 'Describes a more or less one-time decision about the state of the registers counting numbers (initializing the keychain).',
-  required: ['date', 'local', 'remote', 'decision'],
+  description: 'Describes a very infrequent decision about the state of a specific counting number.',
+  required: ['date', 'type', 'decision'],
   properties: {
     date: {
       description: 'Date of a counting number decision',
@@ -47,17 +12,34 @@ module.exports = {
       format: 'date-time',
       example: '2019-01-23 16:51:29.143+00'
     },
-    local: {
-      description: 'Local (POS) counting numbers at the time of the decision',
-      ...countingNumbers
+    type: {
+      type: 'string',
+      description: 'The affected transaction type',
+      enum: [
+        'sale',
+        'expense',
+        'balance',
+        'delivery_note',
+        'saved_cart'
+      ]
     },
-    remote: {
-      description: 'Remote (API) counting numbers at the time of the decision',
-      ...countingNumbers
-    },
+    local: oneOf({
+      type: 'integer',
+      description: 'The local number at the time of the decision.',
+      example: 7,
+      minimum: 0
+    }),
+    remote: oneOf({
+      type: 'integer',
+      description: 'The remote number at the time of the decision.',
+      example: 7,
+      minimum: 0
+    }),
     decision: {
-      description: 'Counting numbers decision, individual max(local, remote)',
-      ...countingNumbers
+      type: 'integer',
+      description: 'The effective number after the decision.',
+      example: 7,
+      minimum: 0
     }
   }
 }

--- a/lib/common/counting_decision.js
+++ b/lib/common/counting_decision.js
@@ -1,10 +1,45 @@
-const { oneOf } = require('../helpers/payload-or-null')
+const countingNumbers = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    sale: {
+      type: 'integer',
+      description: 'The sale counting number at the time of the decision.',
+      example: 37,
+      minimum: 0
+    },
+    expense: {
+      type: 'integer',
+      description: 'The expense counting number at the time of the decision.',
+      example: 19,
+      minimum: 0
+    },
+    balance: {
+      type: 'integer',
+      description: 'The balance counting number at the time of the decision.',
+      example: 5,
+      minimum: 0
+    },
+    delivery_note: {
+      type: 'integer',
+      description: 'The delivery note counting number at the time of the decision.',
+      example: 3,
+      minimum: 0
+    },
+    saved_cart: {
+      type: 'integer',
+      description: 'The saved cart counting number at the time of the decision.',
+      example: 29,
+      minimum: 0
+    }
+  }
+}
 
 module.exports = {
   type: 'object',
   additionalProperties: false,
-  description: 'Describes a very inrequent new decision about the state of a specific counting number.',
-  required: ['date', 'type', 'decision'],
+  description: 'Describes a more or less one-time decision about the state of the registers counting numbers (initializing the keychain).',
+  required: ['date', 'local', 'remote', 'decision'],
   properties: {
     date: {
       description: 'Date of a counting number decision',
@@ -12,34 +47,17 @@ module.exports = {
       format: 'date-time',
       example: '2019-01-23 16:51:29.143+00'
     },
-    type: {
-      type: 'string',
-      description: 'The affected transaction type',
-      enum: [
-        'sale',
-        'expense',
-        'balance',
-        'delivery_note',
-        'saved_cart'
-      ]
+    local: {
+      description: 'Local (POS) counting numbers at the time of the decision',
+      ...countingNumbers
     },
-    local: oneOf({
-      type: 'integer',
-      description: 'The local number at the time of the decision.',
-      example: 7,
-      minimum: 0
-    }),
-    remote: oneOf({
-      type: 'integer',
-      description: 'The remote number at the time of the decision.',
-      example: 7,
-      minimum: 0
-    }),
+    remote: {
+      description: 'Remote (API) counting numbers at the time of the decision',
+      ...countingNumbers
+    },
     decision: {
-      type: 'integer',
-      description: 'The effective number after the decision.',
-      example: 7,
-      minimum: 0
+      description: 'Counting numbers decision, individual max(local, remote)',
+      ...countingNumbers
     }
   }
 }

--- a/lib/v1/balances/legacy/base.js
+++ b/lib/v1/balances/legacy/base.js
@@ -1,7 +1,6 @@
 const { stripIndents } = require('common-tags')
 const { oneOf } = require('../../../helpers/payload-or-null')
 
-const countingDecision = require('../../../common/counting_decision')
 const balanceRevenuesObject = require('./embedded/revenues/base')
 const balanceVatsObject = require('./embedded/vats/base')
 const balanceExpensesObject = require('./embedded/expenses/base')
@@ -25,10 +24,6 @@ module.exports = {
       `
     })
   },
-  counting_decision: oneOf({
-    description: 'If a decision about the counting numbers has been made - it shall be recorded here',
-    ...countingDecision
-  }),
   balance_number: {
     deprecated: true,
     ...oneOf({

--- a/lib/v1/carts/create.request.js
+++ b/lib/v1/carts/create.request.js
@@ -1,6 +1,5 @@
-const { oneOf } = require('../../helpers/payload-or-null')
-const countingDecision = require('../../common/counting_decision')
 const items = require('./items').create
+
 module.exports = {
   $id: 'https://schemas.tillhub.com/v1/carts.create.request.schema.json',
   $schema: 'http://json-schema.org/draft-07/schema#',
@@ -88,10 +87,6 @@ module.exports = {
         }
       ]
     },
-    counting_decision: oneOf({
-      description: 'If a decision about the counting numbers has been made - it shall be recorded here',
-      ...countingDecision
-    }),
     custom_id: {
       oneOf: [
         {

--- a/lib/v1/delivery_notes/base.js
+++ b/lib/v1/delivery_notes/base.js
@@ -1,7 +1,5 @@
-
-const { oneOf } = require('../../helpers/payload-or-null')
-const countingDecision = require('../../common/counting_decision')
 const items = require('./items').create
+
 module.exports = {
   date: {
     oneOf: [
@@ -192,10 +190,6 @@ module.exports = {
       }
     ]
   },
-  counting_decision: oneOf({
-    description: 'If a decision about the counting numbers has been made - it shall be recorded here',
-    ...countingDecision
-  }),
   custom_id: {
     oneOf: [
       {

--- a/lib/v1/registers/base.js
+++ b/lib/v1/registers/base.js
@@ -1,6 +1,8 @@
 const { stripIndents } = require('common-tags')
 const { oneOf } = require('../../helpers/payload-or-null')
 
+const countingDecision = require('../../common/counting_decision')
+
 module.exports = {
   name: {
     anyOf: [
@@ -139,6 +141,12 @@ module.exports = {
                 }
               },
               required: ['ip']
+            })
+          },
+          counting_decision: {
+            ...oneOf({
+              description: 'A one-time decision about the register\'s counting numbers (set when initializing the keychain)',
+              ...countingDecision
             })
           },
           fiscal_signing_type: {

--- a/lib/v1/registers/base.js
+++ b/lib/v1/registers/base.js
@@ -143,10 +143,13 @@ module.exports = {
               required: ['ip']
             })
           },
-          counting_decision: {
+          counting_decisions: {
             ...oneOf({
-              description: 'A one-time decision about the register\'s counting numbers (set when initializing the keychain)',
-              ...countingDecision
+              type: 'array',
+              description: 'Reports a one-time decision about the register\'s counting numbers (set when initializing a safe storage, e.g. keychain)',
+              items: {
+                ...countingDecision
+              }
             })
           },
           fiscal_signing_type: {

--- a/lib/v1/transactions/legacy/base.js
+++ b/lib/v1/transactions/legacy/base.js
@@ -2,7 +2,6 @@ const { stripIndents } = require('common-tags')
 const { oneOf } = require('../../../helpers/payload-or-null')
 const { timezone } = require('../../../common/timezones')
 
-const countingDecision = require('../../../common/counting_decision')
 const relatedObject = require('../components/embedded/reference/related')
 const dependsObject = require('../components/embedded/reference/depends')
 const originObject = require('../components/embedded/reference/origin')
@@ -21,10 +20,6 @@ module.exports = {
       `
     })
   },
-  counting_decision: oneOf({
-    description: 'If a decision about the counting numbers has been made - it shall be recorded here',
-    ...countingDecision
-  }),
   transaction_number: {
     deprecated: true,
     ...oneOf({


### PR DESCRIPTION
this is a counter proposal to the https://github.com/tillhub/schemas/pull/501

store initial (one-time) decision on register instead of arbitrary transaction types

https://tillhub.atlassian.net/browse/IOS-2188

+ add decisions array to v1/registers.device_configuration
- remove decisions from v1/transactions/legacy, v1/balances/legacy, v1/carts, v1/delivers_notes