### PR TITLE
feat(client-accounts): add 'abocard' flag

### DIFF
--- a/lib/v0/client_accounts/features/base.js
+++ b/lib/v0/client_accounts/features/base.js
@@ -66,5 +66,9 @@ module.exports = {
   takeaway: {
     type: 'boolean',
     default: false
+  },
+  abocard: {
+    type: 'boolean',
+    default: false
   }
 }


### PR DESCRIPTION
So we can easily release just to klier and for the time being, no one else