### PR TITLE
[DO NOT MERGE] feat(address): add reservations_google_maps_address to getAddress

### DIFF
--- a/lib/common/address.js
+++ b/lib/common/address.js
@@ -4,6 +4,7 @@ function getAddress ({
   required = [
     'lines',
     'street',
+    'street_number',
     'locality',
     'region',
     'postal_code',
@@ -38,14 +39,16 @@ function getAddress ({
         description: 'Street name',
         example: 'Genthiner Str.',
         ...oneOf({
-          type: 'string'
+          type: 'string',
+          maxLength: 512
         })
       },
       street_number: {
         description: 'Building number',
         example: '34',
         ...oneOf({
-          type: 'string'
+          type: 'string',
+          maxLength: 16
         })
       },
       locality: {
@@ -88,6 +91,19 @@ function getAddress ({
           type: 'string',
           'enum': availableTypes
         })
+      },
+      reservations_google_maps_address: {
+        description: 'The location of the branch on Google Maps',
+        example: 'https://maps.app.goo.gl/tpF7EMsEC7Wy5hmd6',
+        pattern: '^https:\\/\\/maps\\.app\\.goo\\.gl\\/[A-Za-z0-9]*$',
+        oneOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'null'
+          }
+        ]
       }
     }
   }

--- a/lib/v0/branches/base.js
+++ b/lib/v0/branches/base.js
@@ -2,6 +2,7 @@ const { stripIndents } = require('common-tags')
 const customProperties = require('../../common/custom_properties')
 const { oneOf } = require('../../helpers/payload-or-null')
 const { getImages } = require('../../common/images')
+const { getAddress } = require('../../common/address')
 
 module.exports = {
   name: {
@@ -248,152 +249,12 @@ module.exports = {
     ]
   },
   addresses: {
-    description: 'A Tillhub address object, with different types of addresses. More description in the properties...',
+    description: 'A Tillhub address object',
     anyOf: [
       {
         type: 'array',
         maxItems: 3,
-        items: {
-          type: 'object',
-          additionalProperties: false,
-          properties: {
-            lines: {
-              description: 'The international non-street format for arbitrary addresses. This should be set to null as it is currently not supported by the client application.',
-              oneOf: [
-                {
-                  type: 'array',
-                  minItems: 1,
-                  maxItems: 4,
-                  items: {
-                    type: 'string',
-                    minLength: 1
-                  }
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            street: {
-              description: 'A street name',
-              example: 'Downing Street',
-              oneOf: [
-                {
-                  type: 'string',
-                  maxLength: 512
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            street_number: {
-              description: 'A street number',
-              example: '10',
-              oneOf: [
-                {
-                  type: 'string',
-                  maxLength: 16
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            locality: {
-              description: 'The international format for a city, village and any other localizable city like place.',
-              example: 'London',
-              oneOf: [
-                {
-                  type: 'string'
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            region: {
-              description: 'The international format for regional sub category of a country e.g. a state or province.',
-              example: 'Greater London',
-              oneOf: [
-                {
-                  type: 'string'
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            postal_code: {
-              description: 'A non-validated postal code.',
-              example: 'SW1A',
-              oneOf: [
-                {
-                  type: 'string',
-                  maxLength: 10
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            country: {
-              description: 'A country as ISO Alpha-2 code.',
-              example: 'UK',
-              oneOf: [
-                {
-                  type: 'string',
-                  minLength: 2,
-                  maxLength: 2,
-                  pattern: '^[A-Z]{2}$'
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            type: {
-              description: 'The types of addresses. Types are used to direct specific behaviours in financial or stock operation. If none of them is necessary is used implementers should take the local type.',
-              oneOf: [
-                {
-                  type: 'string',
-                  enum: [
-                    'delivery',
-                    'billing',
-                    'local'
-                  ],
-                  default: 'local'
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            },
-            reservations_google_maps_address: {
-              description: 'The location of the branch on Google Maps',
-              example: 'https://maps.app.goo.gl/tpF7EMsEC7Wy5hmd6',
-              pattern: '^https:\\/\\/maps\\.app\\.goo\\.gl\\/[A-Za-z0-9]*$',
-              oneOf: [
-                {
-                  type: 'string'
-                },
-                {
-                  type: 'null'
-                }
-              ]
-            }
-          },
-          required: [
-            'lines',
-            'street',
-            'street_number',
-            'locality',
-            'region',
-            'postal_code',
-            'country',
-            'type'
-          ]
-        }
+        items: getAddress()
       },
       {
         type: 'null'


### PR DESCRIPTION
Suggestions/Notes: 
- reservations_google_maps_address should not belong to the base address in the first place (it's a field used in a specific case and only for branches)
- The main issue now is that it's conflicting with delivery_notes that read address from branch, and when this field exists, it fails the validation as `additionalProperties: false`
- This PR is currently a draft and is treated as POC for now